### PR TITLE
Added support for react@0.13 by updating peerDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   },
   "homepage": "https://github.com/HurricaneJames/react-immutable-proptypes",
   "peerDependencies": {
-    "react": "^0.12.2",
+    "react": ">=0.12.2",
     "immutable": "^3.6.2"
   },
   "devDependencies": {


### PR DESCRIPTION
In the `package.son` the `peerDependencies` are specified as `react@^0.12.2` which does not allow using this package with `react@0.13`. Here is the PR to fix this.