### PR TITLE
ImmutableJS does not need `new` keyword

### DIFF
--- a/src/__tests__/ImmutablePropTypes-test.js
+++ b/src/__tests__/ImmutablePropTypes-test.js
@@ -38,23 +38,23 @@ describe('ImmutablePropTypes', function() {
 
   describe('Primitive Types', function() {
     it('should not warn for valid values', function() {
-      typeCheckPass(PropTypes.list, new Immutable.List());
-      typeCheckPass(PropTypes.map, new Immutable.Map());
-      typeCheckPass(PropTypes.map, new Immutable.OrderedMap());
-      typeCheckPass(PropTypes.orderedMap, new Immutable.OrderedMap());
-      typeCheckPass(PropTypes.set, new Immutable.Set());
-      typeCheckPass(PropTypes.set, new Immutable.OrderedSet());
-      typeCheckPass(PropTypes.orderedSet, new Immutable.OrderedSet());
-      typeCheckPass(PropTypes.stack, new Immutable.Stack());
-      typeCheckPass(PropTypes.seq, new Immutable.Seq());
-      typeCheckPass(PropTypes.iterable, new Immutable.Iterable());
-      typeCheckPass(PropTypes.iterable, new Immutable.List());
-      typeCheckPass(PropTypes.iterable, new Immutable.Map());
-      typeCheckPass(PropTypes.iterable, new Immutable.OrderedMap());
-      typeCheckPass(PropTypes.iterable, new Immutable.Set());
-      typeCheckPass(PropTypes.iterable, new Immutable.OrderedSet());
-      typeCheckPass(PropTypes.iterable, new Immutable.Stack());
-      typeCheckPass(PropTypes.iterable, new Immutable.Seq());
+      typeCheckPass(PropTypes.list, Immutable.List());
+      typeCheckPass(PropTypes.map, Immutable.Map());
+      typeCheckPass(PropTypes.map, Immutable.OrderedMap());
+      typeCheckPass(PropTypes.orderedMap, Immutable.OrderedMap());
+      typeCheckPass(PropTypes.set, Immutable.Set());
+      typeCheckPass(PropTypes.set, Immutable.OrderedSet());
+      typeCheckPass(PropTypes.orderedSet, Immutable.OrderedSet());
+      typeCheckPass(PropTypes.stack, Immutable.Stack());
+      typeCheckPass(PropTypes.seq, Immutable.Seq());
+      typeCheckPass(PropTypes.iterable, Immutable.Iterable());
+      typeCheckPass(PropTypes.iterable, Immutable.List());
+      typeCheckPass(PropTypes.iterable, Immutable.Map());
+      typeCheckPass(PropTypes.iterable, Immutable.OrderedMap());
+      typeCheckPass(PropTypes.iterable, Immutable.Set());
+      typeCheckPass(PropTypes.iterable, Immutable.OrderedSet());
+      typeCheckPass(PropTypes.iterable, Immutable.Stack());
+      typeCheckPass(PropTypes.iterable, Immutable.Seq());
     });
     it('should warn for invalid lists', function() {
       typeCheckFail(
@@ -89,13 +89,13 @@ describe('ImmutablePropTypes', function() {
       );
       typeCheckFail(
         PropTypes.list,
-        new Immutable.Map(),
+        Immutable.Map(),
         'Invalid prop `testProp` of type `object` supplied to ' +
         '`testComponent`, expected `List`.'
       );
       typeCheckFail(
         PropTypes.list,
-        new Immutable.Iterable(),
+        Immutable.Iterable(),
         'Invalid prop `testProp` of type `object` supplied to ' +
         '`testComponent`, expected `List`.'
       );
@@ -133,13 +133,13 @@ describe('ImmutablePropTypes', function() {
       );
       typeCheckFail(
         PropTypes.map,
-        new Immutable.List(),
+        Immutable.List(),
         'Invalid prop `testProp` of type `object` supplied to ' +
         '`testComponent`, expected `Map`.'
       );
       typeCheckFail(
         PropTypes.map,
-        new Immutable.Iterable(),
+        Immutable.Iterable(),
         'Invalid prop `testProp` of type `object` supplied to ' +
         '`testComponent`, expected `Map`.'
       );
@@ -156,15 +156,15 @@ describe('ImmutablePropTypes', function() {
 
   describe('ListOf Type', function() {
     it('should support the listOf propTypes', function() {
-      typeCheckPass(PropTypes.listOf(React.PropTypes.number), new Immutable.List([1, 2, 3]));
-      typeCheckPass(PropTypes.listOf(React.PropTypes.string), new Immutable.List(['a', 'b', 'c']));
-      typeCheckPass(PropTypes.listOf(React.PropTypes.oneOf(['a', 'b'])), new Immutable.List(['a', 'b']));
+      typeCheckPass(PropTypes.listOf(React.PropTypes.number), Immutable.List([1, 2, 3]));
+      typeCheckPass(PropTypes.listOf(React.PropTypes.string), Immutable.List(['a', 'b', 'c']));
+      typeCheckPass(PropTypes.listOf(React.PropTypes.oneOf(['a', 'b'])), Immutable.List(['a', 'b']));
     });
 
     it('should support listOf with complex types', function() {
       typeCheckPass(
         PropTypes.listOf(React.PropTypes.shape({a: React.PropTypes.number.isRequired})),
-        new Immutable.List([{a: 1}, {a: 2}])
+        Immutable.List([{a: 1}, {a: 2}])
       );
 
       typeCheckPass(
@@ -175,14 +175,14 @@ describe('ImmutablePropTypes', function() {
       function Thing() {}
       typeCheckPass(
         PropTypes.listOf(React.PropTypes.instanceOf(Thing)),
-        new Immutable.List([new Thing(), new Thing()])
+        Immutable.List([new Thing(), new Thing()])
       );
     });
 
     it('should warn with invalid items in the list', function() {
       typeCheckFail(
         PropTypes.listOf(React.PropTypes.number),
-        new Immutable.List([1, 2, 'b']),
+        Immutable.List([1, 2, 'b']),
         'Invalid prop `2` of type `string` supplied to `testComponent`, ' +
         'expected `number`.'
       );
@@ -194,7 +194,7 @@ describe('ImmutablePropTypes', function() {
 
       typeCheckFail(
         PropTypes.listOf(React.PropTypes.instanceOf(Thing)),
-        new Immutable.List([new Thing(), 'xyz']),
+        Immutable.List([new Thing(), 'xyz']),
         'Invalid prop `1` supplied to `testComponent`, expected instance of `' +
         name + '`.'
       );
@@ -228,8 +228,8 @@ describe('ImmutablePropTypes', function() {
     });
 
     it('should not warn when passing an empty array', function() {
-      typeCheckPass(PropTypes.listOf(PropTypes.number), new Immutable.List());
-      typeCheckPass(PropTypes.listOf(PropTypes.number), new Immutable.List([]));
+      typeCheckPass(PropTypes.listOf(PropTypes.number), Immutable.List());
+      typeCheckPass(PropTypes.listOf(PropTypes.number), Immutable.List([]));
     });
 
     it('should be implicitly optional and not warn without values', function() {
@@ -253,15 +253,15 @@ describe('ImmutablePropTypes', function() {
 
   describe('MapOf Type', function() {
     it('should support the mapOf propTypes', function() {
-      typeCheckPass(PropTypes.mapOf(React.PropTypes.number), new Immutable.Map({1: 1, 2: 2, 3: 3}));
-      typeCheckPass(PropTypes.mapOf(React.PropTypes.string), new Immutable.Map({1: 'a', 2: 'b', 3: 'c'}));
-      typeCheckPass(PropTypes.mapOf(React.PropTypes.oneOf(['a', 'b'])), new Immutable.Map({1: 'a', 2: 'b'}));
+      typeCheckPass(PropTypes.mapOf(React.PropTypes.number), Immutable.Map({1: 1, 2: 2, 3: 3}));
+      typeCheckPass(PropTypes.mapOf(React.PropTypes.string), Immutable.Map({1: 'a', 2: 'b', 3: 'c'}));
+      typeCheckPass(PropTypes.mapOf(React.PropTypes.oneOf(['a', 'b'])), Immutable.Map({1: 'a', 2: 'b'}));
     });
 
     it('should support mapOf with complex types', function() {
       typeCheckPass(
         PropTypes.mapOf(React.PropTypes.shape({a: React.PropTypes.number.isRequired})),
-        new Immutable.Map({1: {a: 1}, 2: {a: 2}})
+        Immutable.Map({1: {a: 1}, 2: {a: 2}})
       );
 
       typeCheckPass(
@@ -272,14 +272,14 @@ describe('ImmutablePropTypes', function() {
       function Thing() {}
       typeCheckPass(
         PropTypes.mapOf(React.PropTypes.instanceOf(Thing)),
-        new Immutable.Map({ 1: new Thing(), 2: new Thing() })
+        Immutable.Map({ 1: new Thing(), 2: new Thing() })
       );
     });
 
     it('should warn with invalid items in the map', function() {
       typeCheckFail(
         PropTypes.mapOf(React.PropTypes.number),
-        new Immutable.Map({ 1: 1, 2: 2, 3: 'b' }),
+        Immutable.Map({ 1: 1, 2: 2, 3: 'b' }),
         'Invalid prop `2` of type `string` supplied to `testComponent`, ' +
         'expected `number`.'
       );
@@ -291,7 +291,7 @@ describe('ImmutablePropTypes', function() {
 
       typeCheckFail(
         PropTypes.mapOf(React.PropTypes.instanceOf(Thing)),
-        new Immutable.Map({ 1: new Thing(), 2: 'xyz' }),
+        Immutable.Map({ 1: new Thing(), 2: 'xyz' }),
         'Invalid prop `1` supplied to `testComponent`, expected instance of `' +
         name + '`.'
       );
@@ -325,8 +325,8 @@ describe('ImmutablePropTypes', function() {
     });
 
     it('should not warn when passing an empty object', function() {
-      typeCheckPass(PropTypes.mapOf(PropTypes.number), new Immutable.Map());
-      typeCheckPass(PropTypes.mapOf(PropTypes.number), new Immutable.Map({}));
+      typeCheckPass(PropTypes.mapOf(PropTypes.number), Immutable.Map());
+      typeCheckPass(PropTypes.mapOf(PropTypes.number), Immutable.Map({}));
     });
 
     it('should be implicitly optional and not warn without values', function() {
@@ -350,28 +350,28 @@ describe('ImmutablePropTypes', function() {
 
   describe('SetOf Type', function() {
     it('should support the setOf propTypes', function() {
-      typeCheckPass(PropTypes.setOf(React.PropTypes.number), new Immutable.Set([1, 2, 3]));
-      typeCheckPass(PropTypes.setOf(React.PropTypes.string), new Immutable.Set(['a', 'b', 'c']));
-      typeCheckPass(PropTypes.setOf(React.PropTypes.oneOf(['a', 'b'])), new Immutable.Set(['a', 'b']));
+      typeCheckPass(PropTypes.setOf(React.PropTypes.number), Immutable.Set([1, 2, 3]));
+      typeCheckPass(PropTypes.setOf(React.PropTypes.string), Immutable.Set(['a', 'b', 'c']));
+      typeCheckPass(PropTypes.setOf(React.PropTypes.oneOf(['a', 'b'])), Immutable.Set(['a', 'b']));
     });
 
     it('should support setOf with complex types', function() {
       typeCheckPass(
         PropTypes.setOf(React.PropTypes.shape({a: React.PropTypes.number.isRequired})),
-        new Immutable.Set([{a: 1}, {a: 2}])
+        Immutable.Set([{a: 1}, {a: 2}])
       );
 
       function Thing() {}
       typeCheckPass(
         PropTypes.setOf(React.PropTypes.instanceOf(Thing)),
-        new Immutable.Set([new Thing(), new Thing() ])
+        Immutable.Set([new Thing(), new Thing() ])
       );
     });
 
     it('should warn with invalid items in the set', function() {
       typeCheckFail(
         PropTypes.setOf(React.PropTypes.number),
-        new Immutable.Set([1, 2, 'b']),
+        Immutable.Set([1, 2, 'b']),
         'Invalid prop `2` of type `string` supplied to `testComponent`, ' +
         'expected `number`.'
       );
@@ -383,7 +383,7 @@ describe('ImmutablePropTypes', function() {
 
       typeCheckFail(
         PropTypes.setOf(React.PropTypes.instanceOf(Thing)),
-        new Immutable.Set([new Thing(), 'xyz' ]),
+        Immutable.Set([new Thing(), 'xyz' ]),
         'Invalid prop `1` supplied to `testComponent`, expected instance of `' +
         name + '`.'
       );
@@ -417,8 +417,8 @@ describe('ImmutablePropTypes', function() {
     });
 
     it('should not warn when passing an empty object', function() {
-      typeCheckPass(PropTypes.setOf(PropTypes.number), new Immutable.Set());
-      typeCheckPass(PropTypes.setOf(PropTypes.number), new Immutable.Set([]));
+      typeCheckPass(PropTypes.setOf(PropTypes.number), Immutable.Set());
+      typeCheckPass(PropTypes.setOf(PropTypes.number), Immutable.Set([]));
     });
 
     it('should be implicitly optional and not warn without values', function() {
@@ -442,13 +442,13 @@ describe('ImmutablePropTypes', function() {
 
   describe('IterableOf Type', function() {
     it('should support the iterableOf propTypes', function() {
-      typeCheckPass(PropTypes.iterableOf(React.PropTypes.number), new Immutable.List([1, 2, 3]));
-      typeCheckPass(PropTypes.iterableOf(React.PropTypes.string), new Immutable.List(['a', 'b', 'c']));
-      typeCheckPass(PropTypes.iterableOf(React.PropTypes.oneOf(['a', 'b'])), new Immutable.List(['a', 'b']));
+      typeCheckPass(PropTypes.iterableOf(React.PropTypes.number), Immutable.List([1, 2, 3]));
+      typeCheckPass(PropTypes.iterableOf(React.PropTypes.string), Immutable.List(['a', 'b', 'c']));
+      typeCheckPass(PropTypes.iterableOf(React.PropTypes.oneOf(['a', 'b'])), Immutable.List(['a', 'b']));
 
-      typeCheckPass(PropTypes.iterableOf(React.PropTypes.number), new Immutable.Map({1: 1, 2: 2, 3: 3}));
-      typeCheckPass(PropTypes.iterableOf(React.PropTypes.string), new Immutable.Map({1: 'a', 2: 'b', 3: 'c'}));
-      typeCheckPass(PropTypes.iterableOf(React.PropTypes.oneOf(['a', 'b'])), new Immutable.Map({1: 'a', 2: 'b'}));
+      typeCheckPass(PropTypes.iterableOf(React.PropTypes.number), Immutable.Map({1: 1, 2: 2, 3: 3}));
+      typeCheckPass(PropTypes.iterableOf(React.PropTypes.string), Immutable.Map({1: 'a', 2: 'b', 3: 'c'}));
+      typeCheckPass(PropTypes.iterableOf(React.PropTypes.oneOf(['a', 'b'])), Immutable.Map({1: 'a', 2: 'b'}));
     });
 
     it('should support iterableOf with complex types', function() {
@@ -456,7 +456,7 @@ describe('ImmutablePropTypes', function() {
 
       typeCheckPass(
         PropTypes.iterableOf(React.PropTypes.shape({a: React.PropTypes.number.isRequired})),
-        new Immutable.List([{a: 1}, {a: 2}])
+        Immutable.List([{a: 1}, {a: 2}])
       );
 
       typeCheckPass(
@@ -466,12 +466,12 @@ describe('ImmutablePropTypes', function() {
 
       typeCheckPass(
         PropTypes.iterableOf(React.PropTypes.instanceOf(Thing)),
-        new Immutable.List([new Thing(), new Thing()])
+        Immutable.List([new Thing(), new Thing()])
       );
 
       typeCheckPass(
         PropTypes.iterableOf(React.PropTypes.shape({a: React.PropTypes.number.isRequired})),
-        new Immutable.Map({1: {a: 1}, 2: {a: 2}})
+        Immutable.Map({1: {a: 1}, 2: {a: 2}})
       );
 
       typeCheckPass(
@@ -481,21 +481,21 @@ describe('ImmutablePropTypes', function() {
 
       typeCheckPass(
         PropTypes.iterableOf(React.PropTypes.instanceOf(Thing)),
-        new Immutable.Map({ 1: new Thing(), 2: new Thing() })
+        Immutable.Map({ 1: new Thing(), 2: new Thing() })
       );
     });
 
     it('should warn with invalid items in the list', function() {
       typeCheckFail(
         PropTypes.iterableOf(React.PropTypes.number),
-        new Immutable.List([1, 2, 'b']),
+        Immutable.List([1, 2, 'b']),
         'Invalid prop `2` of type `string` supplied to `testComponent`, ' +
         'expected `number`.'
       );
 
       typeCheckFail(
         PropTypes.iterableOf(React.PropTypes.number),
-        new Immutable.Map({ 1: 1, 2: 2, 3: 'b' }),
+        Immutable.Map({ 1: 1, 2: 2, 3: 'b' }),
         'Invalid prop `2` of type `string` supplied to `testComponent`, ' +
         'expected `number`.'
       );
@@ -507,14 +507,14 @@ describe('ImmutablePropTypes', function() {
 
       typeCheckFail(
         PropTypes.iterableOf(React.PropTypes.instanceOf(Thing)),
-        new Immutable.List([new Thing(), 'xyz']),
+        Immutable.List([new Thing(), 'xyz']),
         'Invalid prop `1` supplied to `testComponent`, expected instance of `' +
         name + '`.'
       );
 
       typeCheckFail(
         PropTypes.iterableOf(React.PropTypes.instanceOf(Thing)),
-        new Immutable.Map({ 1: new Thing(), 2: 'xyz' }),
+        Immutable.Map({ 1: new Thing(), 2: 'xyz' }),
         'Invalid prop `1` supplied to `testComponent`, expected instance of `' +
         name + '`.'
       );
@@ -548,9 +548,9 @@ describe('ImmutablePropTypes', function() {
     });
 
     it('should not warn when passing an empty iterable', function() {
-      typeCheckPass(PropTypes.iterableOf(PropTypes.number), new Immutable.List());
-      typeCheckPass(PropTypes.iterableOf(PropTypes.number), new Immutable.List([]));
-      typeCheckPass(PropTypes.iterableOf(PropTypes.number), new Immutable.Map({}));
+      typeCheckPass(PropTypes.iterableOf(PropTypes.number), Immutable.List());
+      typeCheckPass(PropTypes.iterableOf(PropTypes.number), Immutable.List([]));
+      typeCheckPass(PropTypes.iterableOf(PropTypes.number), Immutable.Map({}));
     });
 
     it('should be implicitly optional and not warn without values', function() {
@@ -671,7 +671,7 @@ describe('ImmutablePropTypes', function() {
         1: React.PropTypes.string.isRequired,
         2: React.PropTypes.string
       };
-      typeCheckPass(PropTypes.shape(shape), new Immutable.List([1, '2']));
+      typeCheckPass(PropTypes.shape(shape), Immutable.List([1, '2']));
     });
   });
 
@@ -774,7 +774,7 @@ describe('ImmutablePropTypes', function() {
         1: React.PropTypes.string.isRequired,
         2: React.PropTypes.string
       };
-      typeCheckPass(PropTypes.contains(contains), new Immutable.List([1, '2']));
+      typeCheckPass(PropTypes.contains(contains), Immutable.List([1, '2']));
     });
   });
 });


### PR DESCRIPTION
Everything works the same way. No `new` in docs https://facebook.github.io/immutable-js/ too.

PS: we use ImmutableJS for almost a year now, never added `new`