### PR TITLE
If typeChecker is not a correct checker, return an error

### DIFF
--- a/src/ImmutablePropTypes.js
+++ b/src/ImmutablePropTypes.js
@@ -78,6 +78,7 @@ function createImmutableTypeChecker(immutableClassName, immutableClassTypeValida
 }
 
 function createIterableTypeChecker(typeChecker, immutableClassName, immutableClassTypeValidator) {
+
   function validate(props, propName, componentName, location) {
     var propValue = props[propName];
     if (!immutableClassTypeValidator(propValue)) {
@@ -90,6 +91,12 @@ function createIterableTypeChecker(typeChecker, immutableClassName, immutableCla
     }
     var propValues = propValue.toArray();
     for (var i = 0, len = propValues.length; i < len; i++) {
+      if (typeof typeChecker !== 'function') {
+        return new Error(
+          `Invalid typeChecker supplied to \`${componentName}\` ` +
+          `for propType \`${propName}\`, expected a function.`
+        );
+      }
       var error = typeChecker(propValues, i, componentName, location);
       if (error instanceof Error) {
         return error;

--- a/src/__tests__/ImmutablePropTypes-test.js
+++ b/src/__tests__/ImmutablePropTypes-test.js
@@ -36,6 +36,20 @@ describe('ImmutablePropTypes', function() {
     Immutable = require('immutable');
   });
 
+  describe('PropTypes config', function() {
+    it('should fail if typeChecker is not a function', function() {
+      typeCheckFail(
+        PropTypes.listOf({x: React.PropTypes.string}),
+        Immutable.List([Immutable.Map({x: 'y'})]),
+        'Invalid typeChecker supplied to ' +
+        '`testComponent` for propType `testProp`, expected a function.'
+      );
+      typeCheckPass(
+        PropTypes.listOf(PropTypes.contains({x: React.PropTypes.string})),
+        Immutable.List([Immutable.Map({x: 'y'})]));
+    });
+  });
+
   describe('Primitive Types', function() {
     it('should not warn for valid values', function() {
       typeCheckPass(PropTypes.list, new Immutable.List());


### PR DESCRIPTION
It is really hard to trace down this error.
Sometimes I forget to add `contains()` using `listOf()`, for example:

```js
  propTypes: {
    data: contains({
      inbound: listOf({
                     ^^^ missing `contains`
        ts: PropTypes.Timestamp.isRequired,
        value: React.PropTypes.number.isRequired
      }),
      outbound: listOf(contains({
        ts: PropTypes.Timestamp.isRequired,
        value: React.PropTypes.number.isRequired
      }))
    }).isRequired
  }
```

Then I get a pretty cryptic warning (when I render component with some data):

<img width="993" alt="20150930-190935" src="https://cloud.githubusercontent.com/assets/175264/10188997/0d116932-67a7-11e5-9c05-0bc6ed30272a.png">

Which requires quite a bit of debugging to figure out what is wrong.

With this change warning looks like:

<img width="974" alt="20150930-190913" src="https://cloud.githubusercontent.com/assets/175264/10189023/31a4401c-67a7-11e5-87f7-50e3f38af894.png">

And that helps a lot to find what is actually broken.


Also added unit test for this.