### PR TITLE
Better .npmignore + Allow ES6 sources

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,1 +1,4 @@
-src
+/scripts/
+__tests__
+/.*
+/babel.js


### PR DESCRIPTION
Tested with local install
```
[nkbt@nkbt] tmp $ npm install ~/github/react-immutable-proptypes
 
> react-immutable-proptypes@1.2.1 prepublish /Users/nkbt/github/react-immutable-proptypes
> npm run build

/
> react-immutable-proptypes@1.2.1 build /Users/nkbt/github/react-immutable-proptypes
> ./scripts/build

src/ImmutablePropTypes.js -> dist/ImmutablePropTypes.js
src/__tests__/ImmutablePropTypes-test.js -> dist/__tests__/ImmutablePropTypes-test.js
react-immutable-proptypes@1.2.1 node_modules/react-immutable-proptypes


[nkbt@nkbt] tmp $ find node_modules/react-immutable-proptypes
node_modules/react-immutable-proptypes
node_modules/react-immutable-proptypes/CHANGELOG.md
node_modules/react-immutable-proptypes/dist
node_modules/react-immutable-proptypes/dist/ImmutablePropTypes.js
node_modules/react-immutable-proptypes/LICENSE
node_modules/react-immutable-proptypes/package.json
node_modules/react-immutable-proptypes/README.md
node_modules/react-immutable-proptypes/src
node_modules/react-immutable-proptypes/src/ImmutablePropTypes.js
```