### PR TITLE
Bug fix for createIterableTypeChecker passing propValue incorrectly

### DIFF
--- a/src/ImmutablePropTypes.js
+++ b/src/ImmutablePropTypes.js
@@ -50,7 +50,7 @@ function getPropType(propValue) {
 function createChainableTypeChecker(validate) {
   function checkType(isRequired, props, propName, componentName, location) {
     componentName = componentName || ANONYMOUS;
-    if (props[propName] == null) {
+    if (props[propName] === null) {
       var locationName = location;
       if (isRequired) {
         return new Error(
@@ -96,19 +96,18 @@ function createIterableTypeChecker(typeChecker, immutableClassName, immutableCla
         `\`${propType}\` supplied to \`${componentName}\`, expected an Immutable.js ${immutableClassName}.`
       );
     }
-    var propValues = propValue.toArray();
-    for (var i = 0, len = propValues.length; i < len; i++) {
-      if (typeof typeChecker !== 'function') {
-        return new Error(
-          `Invalid typeChecker supplied to \`${componentName}\` ` +
-          `for propType \`${propName}\`, expected a function.`
-        );
-      }
-      var error = typeChecker(propValues, i, componentName, location);
+    if (typeof typeChecker !== 'function') {
+      return new Error(
+        `Invalid typeChecker supplied to \`${componentName}\` ` +
+        `for propType \`${propName}\`, expected a function.`
+      );
+    }
+    propValue.forEach(function(value, i) {
+      var error = typeChecker(propValue, i, componentName, location);
       if (error instanceof Error) {
         return error;
       }
-    }
+    });
   }
   return createChainableTypeChecker(validate);
 }


### PR DESCRIPTION
Let's say that the following is a validation I've set up in my component:

```javascript
import React from 'react';
import ImmutablePropTypes from 'react-immutable-proptypes';

var MyComponent = React.createClass({
  propTypes: {
    someImmutableList: ImmutablePropTypes.listOf(myAwesomeListValidator)
  },
  render: function() {...}
});

function myAwesomeListValidator(list, idx, componentName, location) {
  var currListItem = list.get(idx);
  ...
}
```

If you try running the above, you will get an error along the lines of:

```
Warning: Failed propType: list.get is not a function ...
```

I literally spent hours trying to figure out what I had done to my prop to somehow make it not a list. But it didn't make any sense, since putting a `console.log(this.props.someImmutableList)` easily shows it is an Immutable list. Well, after some code hunting, I found this in the current source:

```javascript
var propValues = propValue.toArray();
```

Well now it all makes total sense! So, this changes fixes this (what I deem a bug) by preserving the Immutable structure, and replacing the for loop for `forEach`, [a method that all Immutable.js structure inherit from Immutable.Iterable](http://facebook.github.io/immutable-js/docs/#/Iterable/forEach).

*Warning:* this change will potentially break existing code for anyone who has provided a custom typechecker to `ImmutablePropTypes.listOf`. However, in the long run their code should change - ideally there is no reason to ever not use Immutable.js objects completely.