### PR TITLE
Experimental implementation for recordOf(Type)

### DIFF
--- a/src/ImmutablePropTypes.js
+++ b/src/ImmutablePropTypes.js
@@ -150,6 +150,18 @@ function createRecordOfTypeChecker(recordKeys) {
         `supplied to \`${componentName}\`, expected an Immutable.js Record.`
       );
     }
+
+    if (recordKeys.constructor !== Object) {
+      if (!(propValue instanceof recordKeys)) {
+        return new Error(
+            `Invalid ${location} \`${propName}\` supplied to \`${componentName}\`, ` +
+            `expected Immutable.js Record of different type.`
+        );
+      }
+
+      return undefined;
+    }
+
     for (var key in recordKeys) {
       var checker = recordKeys[key];
       if (!checker) {

--- a/src/__tests__/ImmutablePropTypes-test.js
+++ b/src/__tests__/ImmutablePropTypes-test.js
@@ -936,6 +936,23 @@ describe('ImmutablePropTypes', function() {
         requiredMessage
       );
     });
+
+    it('should accept Records', function() {
+      var Type = new Immutable.Record({});
+
+      typeCheckPass(PropTypes.recordOf(Type), new Type());
+    });
+
+    it('should not accept wrong Records', function() {
+      var TypeA = new Immutable.Record({});
+      var TypeB = new Immutable.Record({});
+
+      typeCheckFail(
+          PropTypes.recordOf(TypeA),
+          new TypeB(),
+          'Invalid prop `testProp` supplied to `testComponent`, expected Immutable.js Record of different type.'
+      );
+    });
   });
 
   describe('Shape Types [deprecated]', function() {


### PR DESCRIPTION
This is just a POC implementation for #19

As you may spot to check if it's a plain-old JS object I'm using the ugly

```js
if (recordKeys.constructor !== Object) {
```
check.

That is necessary since at the moment there is no (?) way to check if a custom type is an instance of the `Immutable.Record`. For that I sent a feature request: https://github.com/facebook/immutable-js/issues/775

Any thoughts?