### PR TITLE
add mapContains prop type

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,8 @@ ImmutablePropTypes.stack        // Immutable.Stack.isStack
 ImmutablePropTypes.seq          // Immutable.Seq.isSeq
 ImmutablePropTypes.iterable     // Immutable.Iterable.isIterable
 ImmutablePropTypes.record       // instanceof Record
+ImmutablePropTypes.contains     // Immutable.Iterable.isIterable - contains(shape)
+ImmutablePropTypes.mapContains  // Immutable.Map.isMap - contains(shape)
 ```
 
 * `ImmutablePropTypes.listOf` is based on `React.PropTypes.array` and is specific to `Immutable.List`.
@@ -83,23 +85,20 @@ aRecord: ImmutablePropTypes.recordOf({
 // ...
 ```
 
-* `ImmutablePropTypes.contains` (formerly `shape`) is based on `React.PropTypes.shape` and will try to work with any `Immutable.Iterable`. In practice, I would recommend limiting this to `Immutable.Map` or `Immutable.OrderedMap`. However, it is possible to abuse `contains` to validate an array via `Immutable.List`.
+* `ImmutablePropTypes.contains` (formerly `shape`) is based on `React.PropTypes.shape` and will try to work with any `Immutable.Iterable`. In practice, I would recommend limiting this to `Immutable.Map`(suggested to use `ImmutablePropTypes.mapContains`) or `Immutable.OrderedMap`. However, it is possible to abuse `contains` to validate an array via `Immutable.List`. That said, please, just... don't.
+
+* `ImmutablePropTypes.mapContains` is based on `React.PropTypes.shape` and will only work with `Immutable.Map`.
 
 ```es6
 // ...
-aList: ImmutablePropTypes.contains({
-    0: React.PropTypes.number.isRequired,
-    1: React.PropTypes.string.isRequired,
-    2: React.PropTypes.string
+aMap: ImmutablePropTypes.mapContains({
+    aList: ImmutablePropTypes.list.isRequired,
 })
 // ...
-<SomeComponent aList={Immutable.List([1, '2'])} />
+<SomeComponent aList={Immutable.fromJS({aList: [1, 2]})} />
 ```
 
-That said, don't do this. Please, just... don't.
-
 These two validators cover the output of `Immutable.fromJS` on standard JSON data sources.
-
 
 ## RFC
 

--- a/src/__tests__/ImmutablePropTypes-test.js
+++ b/src/__tests__/ImmutablePropTypes-test.js
@@ -1235,4 +1235,134 @@ describe('ImmutablePropTypes', function() {
       typeCheckPass(PropTypes.contains(contains), Immutable.List([1, '2']));
     });
   });
+
+  describe('MapContains Types', function() {
+    it('should warn for non objects', function() {
+      typeCheckFail(
+        PropTypes.mapContains({}),
+        'some string',
+        'Invalid prop `testProp` of type `string` supplied to ' +
+        '`testComponent`, expected an Immutable.js Map.'
+      );
+      typeCheckFail(
+        PropTypes.mapContains({}),
+        ['array'],
+        'Invalid prop `testProp` of type `array` supplied to ' +
+        '`testComponent`, expected an Immutable.js Map.'
+      );
+      typeCheckFail(
+        PropTypes.mapContains({}),
+        {a: 1},
+        'Invalid prop `testProp` of type `object` supplied to ' +
+        '`testComponent`, expected an Immutable.js Map.'
+      );
+    });
+
+    it('should not warn for empty values', function() {
+      typeCheckPass(PropTypes.mapContains({}), undefined);
+      typeCheckPass(PropTypes.mapContains({}), null);
+      typeCheckPass(PropTypes.mapContains({}), Immutable.fromJS({}));
+    });
+
+    it('should not warn for an empty Immutable object', function() {
+      typeCheckPass(PropTypes.mapContains({}).isRequired, Immutable.fromJS({}));
+    });
+
+    it('should not warn for non specified types', function() {
+      typeCheckPass(PropTypes.mapContains({}), Immutable.fromJS({key: 1}));
+    });
+
+    it('should not warn for valid types', function() {
+      typeCheckPass(PropTypes.mapContains({key: React.PropTypes.number}), Immutable.fromJS({key: 1}));
+    });
+
+    it('should not warn for nested valid types', function() {
+      typeCheckPass(
+        PropTypes.mapContains({
+          data: PropTypes.listOf(PropTypes.mapContains({
+            id: React.PropTypes.number.isRequired
+          })).isRequired
+        }),
+        Immutable.fromJS({data: [{id: 1}, {id: 2}]})
+      );
+    });
+
+    it('should warn for nested invalid types', function() {
+      typeCheckFail(
+        PropTypes.mapContains({
+          data: PropTypes.listOf(PropTypes.mapContains({
+            id: React.PropTypes.number.isRequired
+          })).isRequired
+        }),
+        Immutable.fromJS({data: [{id: 1}, {}]}),
+        'Required prop `id` was not specified in `testComponent`.'
+      );
+    });
+
+    it('should ignore null keys', function() {
+      typeCheckPass(PropTypes.mapContains({key: null}), Immutable.fromJS({key: 1}));
+    });
+
+    it('should warn for required valid types', function() {
+      typeCheckFail(
+        PropTypes.mapContains({key: React.PropTypes.number.isRequired}),
+        Immutable.fromJS({}),
+        'Required prop `key` was not specified in `testComponent`.'
+      );
+    });
+
+    it('should warn for the first required type', function() {
+      typeCheckFail(
+        PropTypes.mapContains({
+          key: React.PropTypes.number.isRequired,
+          secondKey: React.PropTypes.number.isRequired
+        }),
+        Immutable.fromJS({}),
+        'Required prop `key` was not specified in `testComponent`.'
+      );
+    });
+
+    it('should warn for invalid key types', function() {
+      typeCheckFail(PropTypes.mapContains({key: React.PropTypes.number}),
+        Immutable.fromJS({key: 'abc'}),
+        'Invalid prop `key` of type `string` supplied to `testComponent`, ' +
+        'expected `number`.'
+      );
+    });
+
+    it('should be implicitly optional and not warn without values', function() {
+      typeCheckPass(
+        PropTypes.mapContains(PropTypes.mapContains({key: React.PropTypes.number})), null
+      );
+      typeCheckPass(
+        PropTypes.mapContains(PropTypes.mapContains({key: React.PropTypes.number})), undefined
+      );
+    });
+
+    it('should warn for missing required values', function() {
+      typeCheckFail(
+        PropTypes.mapContains({key: React.PropTypes.number}).isRequired,
+        null,
+        requiredMessage
+      );
+      typeCheckFail(
+        PropTypes.mapContains({key: React.PropTypes.number}).isRequired,
+        undefined,
+        requiredMessage
+      );
+    });
+
+    it('should not validate a list', function() {
+      var contains = {
+        0: React.PropTypes.number.isRequired,
+        1: React.PropTypes.string.isRequired,
+        2: React.PropTypes.string
+      };
+      typeCheckFail(
+        PropTypes.mapContains(contains),
+        Immutable.List([1, '2']),
+        'Invalid prop `testProp` of type `Immutable.List` supplied to `testComponent`, expected an Immutable.js Map.'
+      );
+    });
+  });
 });


### PR DESCRIPTION
attempt to add functionality for #15 

Example data:
```
Immutable.fromJS({
    name: 'bobiton',
    nickname: 'thebob',
    pictures: ['/bobswimming.jpg', 'bobflying.jpg']
})
```

Example proptypes:
```
static propTypes = {
    user: ImmutablePropTypes.mapContains({
        name: PropTypes.string.isRequired,
        nickname: PropTypes.string.isRequired,
        pictures: ImmutablePropTypes.listOf(PropTypes.string.isRequired)
    })
};
```

please give feedback. maybe a different name? `mapShapeOf`, `mapHasShape`

I will update the docs when/if this functionality is agreed upon.