### PR TITLE
mapOf (+orderedMapOf) - keys validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,9 +66,26 @@ ImmutablePropTypes.mapContains  // Immutable.Map.isMap - contains(shape)
 
 * `ImmutablePropTypes.listOf` is based on `React.PropTypes.array` and is specific to `Immutable.List`.
 
-* `ImmutablePropTypes.mapOf` is basically the same as `listOf`, but it is specific to `Immutable.Map` It will check that the prop is an Immutable.Map and that the values are of the specified type.
+* `ImmutablePropTypes.mapOf` allows you to control both map values nad keys (in Immutable.Map, keys could be _anything_ including another Immutable collections). It accepts two arguments - first one for values, second one for keys (optional). If you are interested in validation of keys only, just pass `React.PropTypes.any` as the first argument.
 
-* `ImmutablePropTypes.orderedMapOf` is basically the same as `listOf`, but it is specific to `Immutable.OrderedMap`.
+```es6
+// ...
+aMap: ImmutablePropTypes.mapOf(
+    React.PropTypes.any, // validation for values
+    ImmutablePropTypes.mapContains({ // validation for keys
+        a: React.PropTypes.number.isRequired,
+        b: React.PropTypes.string
+    })
+)
+// ...
+const aMap = Immutable.Map([
+    [Immutable.Map({a: 1, b: '2'}), 'foo'],
+    [Immutable.Map({a: 3}), [1, '2', 3]]
+]);
+<SomeComponent aMap={aMap} />
+```
+
+* `ImmutablePropTypes.orderedMapOf` is basically the same as `mapOf`, but it is specific to `Immutable.OrderedMap`.
 
 * `ImmutablePropTypes.orderedSetOf` is basically the same as `listOf`, but it is specific to `Immutable.OrderedSet`.
 

--- a/src/__tests__/ImmutablePropTypes-test.js
+++ b/src/__tests__/ImmutablePropTypes-test.js
@@ -498,6 +498,88 @@ describe('ImmutablePropTypes', function() {
         requiredMessage
       );
     });
+
+    it('should support keys validation by passing typeChecker as a second argument', function() {
+      typeCheckPass(
+        PropTypes.mapOf(
+          React.PropTypes.any,
+          React.PropTypes.string
+        ),
+        Immutable.Map({a: 1, b: 2})
+      );
+      typeCheckPass(
+        PropTypes.mapOf(
+          React.PropTypes.any,
+          React.PropTypes.number
+        ),
+        Immutable.Map([[1, 1], [1, 2]])
+      );
+      typeCheckPass(
+        PropTypes.mapOf(
+          React.PropTypes.any,
+          React.PropTypes.function
+        ),
+        Immutable.Map([[() => 1 + 1, 1], [(foo) => 'bar', 2]])
+      );
+    });
+
+    it('should support keys validation with Immutable keys', function() {
+      typeCheckPass(
+        PropTypes.mapOf(
+          React.PropTypes.any,
+          PropTypes.mapContains({
+            a: React.PropTypes.number.isRequired,
+            b: React.PropTypes.string
+          })
+        ),
+        Immutable.Map([
+          [Immutable.Map({a: 1, b: '2'}), 1],
+          [Immutable.Map({a: 3}), 2]
+        ])
+      );
+    });
+
+    it('should warn with invalid keys in the map', function() {
+      typeCheckFail(
+        PropTypes.mapOf(
+          React.PropTypes.any,
+          React.PropTypes.number
+        ),
+        Immutable.Map({a: 1, b: 2}),
+        'Invalid prop `testProp -> key(a)` of type `string` supplied to `testComponent`, ' +
+        'expected `number`.'
+      );
+
+      typeCheckFail(
+        PropTypes.mapOf(
+          React.PropTypes.any,
+          React.PropTypes.string
+        ),
+        Immutable.Map([
+          [{a: 1}, 2],
+          ['a', 1]
+        ]),
+        'Invalid prop `testProp -> key([object Object])` of type `object` supplied to `testComponent`, ' +
+        'expected `string`.'
+      );
+    });
+
+    it('should cause inner warning with invalid immutable key in the map', function() {
+      typeCheckFail(
+        PropTypes.mapOf(
+          React.PropTypes.any,
+          PropTypes.mapContains({
+            a: React.PropTypes.number.isRequired,
+            b: React.PropTypes.string
+          })
+        ),
+        Immutable.Map([
+          [Immutable.Map({b: '2'}), 1],
+          [Immutable.Map({a: 3}), 2]
+        ]),
+        'Required prop `testProp -> key(Map { "b": "2" }).a` was not specified in `testComponent`.'
+      );
+    });
   });
 
   describe('OrderedMapOf Type', function() {
@@ -599,6 +681,88 @@ describe('ImmutablePropTypes', function() {
         PropTypes.orderedMapOf(React.PropTypes.number).isRequired,
         undefined,
         requiredMessage
+      );
+    });
+
+    it('should support keys validation by passing typeChecker as a second argument', function() {
+      typeCheckPass(
+        PropTypes.orderedMapOf(
+          React.PropTypes.any,
+          React.PropTypes.string
+        ),
+        Immutable.OrderedMap({a: 1, b: 2})
+      );
+      typeCheckPass(
+        PropTypes.orderedMapOf(
+          React.PropTypes.any,
+          React.PropTypes.number
+        ),
+        Immutable.OrderedMap([[1, 1], [1, 2]])
+      );
+      typeCheckPass(
+        PropTypes.orderedMapOf(
+          React.PropTypes.any,
+          React.PropTypes.function
+        ),
+        Immutable.OrderedMap([[() => 1 + 1, 1], [(foo) => 'bar', 2]])
+      );
+    });
+
+    it('should support keys validation with Immutable keys', function() {
+      typeCheckPass(
+        PropTypes.orderedMapOf(
+          React.PropTypes.any,
+          PropTypes.mapContains({
+            a: React.PropTypes.number.isRequired,
+            b: React.PropTypes.string
+          })
+        ),
+        Immutable.OrderedMap([
+          [Immutable.Map({a: 1, b: '2'}), 1],
+          [Immutable.Map({a: 3}), 2]
+        ])
+      );
+    });
+
+    it('should warn with invalid keys in the map', function() {
+      typeCheckFail(
+        PropTypes.orderedMapOf(
+          React.PropTypes.any,
+          React.PropTypes.number
+        ),
+        Immutable.OrderedMap({a: 1, b: 2}),
+        'Invalid prop `testProp -> key(a)` of type `string` supplied to `testComponent`, ' +
+        'expected `number`.'
+      );
+
+      typeCheckFail(
+        PropTypes.orderedMapOf(
+          React.PropTypes.any,
+          React.PropTypes.string
+        ),
+        Immutable.OrderedMap([
+          [{a: 1}, 2],
+          ['a', 1]
+        ]),
+        'Invalid prop `testProp -> key([object Object])` of type `object` supplied to `testComponent`, ' +
+        'expected `string`.'
+      );
+    });
+
+    it('should cause inner warning with invalid immutable key in the map', function() {
+      typeCheckFail(
+        PropTypes.orderedMapOf(
+          React.PropTypes.any,
+          PropTypes.mapContains({
+            a: React.PropTypes.number.isRequired,
+            b: React.PropTypes.string
+          })
+        ),
+        Immutable.OrderedMap([
+          [Immutable.Map({b: '2'}), 1],
+          [Immutable.Map({a: 3}), 2]
+        ]),
+        'Required prop `testProp -> key(Map { "b": "2" }).a` was not specified in `testComponent`.'
       );
     });
   });


### PR DESCRIPTION
In Immutable, it makes sense to also control propTypes of Immutable.(Ordered)Map keys.

So I implemented this as the second (optional) argument of `mapOf / orderedMapOf` functions. 
And of course, I also covered new use-cases with tests.

I hope you like this :)