### PR TITLE
Defer performance-intensive error message generation until needed

### DIFF
--- a/src/ImmutablePropTypes.js
+++ b/src/ImmutablePropTypes.js
@@ -149,8 +149,8 @@ function createIterableOfTypeChecker(typeChecker) {
 function createRecordOfTypeChecker(recordKeys) {
   function validate(props, propName, componentName, location, propFullName) {
     var propValue = props[propName];
-    var propType = getPropType(propValue);
     if (!(propValue instanceof Immutable.Record)) {
+      var propType = getPropType(propValue);
       var locationName = location;
       return new Error(
         `Invalid ${locationName} \`${propFullName}\` of type \`${propType}\` ` +
@@ -176,8 +176,8 @@ function createRecordOfTypeChecker(recordKeys) {
 function createShapeTypeChecker(shapeTypes, immutableClassName = 'Iterable', immutableClassTypeValidator = Immutable.Iterable.isIterable) {
   function validate(props, propName, componentName, location, propFullName) {
     var propValue = props[propName];
-    var propType = getPropType(propValue);
     if (!immutableClassTypeValidator(propValue)) {
+      var propType = getPropType(propValue);
       var locationName = location;
       return new Error(
         `Invalid ${locationName} \`${propFullName}\` of type \`${propType}\` ` +


### PR DESCRIPTION
`getPropType` has poor time complexity as it calls `.toSource` which serialises the entire Immutable data structure, and in some of the checkers this function is being unnecessarily called, even when no error has occured. As the data structure being checked grows large this can very noticeably slow down rendering (in development, at least). This PR moves calls to `getPropType` in the Record and Shape checkers so it is only called in an error case.

Ideally the implementation of `getPropType` wouldn't call `.toSource` but I couldn't easily come up with an alternative which works for all data structures, for all versions of immutable-js (something for another PR perhaps).