### PR TITLE
Update for React 15.3.0 to remove warnings

### DIFF
--- a/src/ImmutablePropTypes.js
+++ b/src/ImmutablePropTypes.js
@@ -50,7 +50,7 @@ function getPropType(propValue) {
 }
 
 function createChainableTypeChecker(validate) {
-  function checkType(isRequired, props, propName, componentName, location, propFullName) {
+  function checkType(isRequired, props, propName, componentName, location, propFullName, ...rest) {
     propFullName = propFullName || propName;
     componentName = componentName || ANONYMOUS;
     if (props[propName] == null) {
@@ -62,7 +62,7 @@ function createChainableTypeChecker(validate) {
         );
       }
     } else {
-      return validate(props, propName, componentName, location, propFullName);
+      return validate(props, propName, componentName, location, propFullName, ...rest);
     }
   }
 
@@ -89,7 +89,7 @@ function createImmutableTypeChecker(immutableClassName, immutableClassTypeValida
 
 function createIterableTypeChecker(typeChecker, immutableClassName, immutableClassTypeValidator) {
 
-  function validate(props, propName, componentName, location, propFullName) {
+  function validate(props, propName, componentName, location, propFullName, ...rest) {
     var propValue = props[propName];
     if (!immutableClassTypeValidator(propValue)) {
       var locationName = location;
@@ -109,7 +109,7 @@ function createIterableTypeChecker(typeChecker, immutableClassName, immutableCla
 
     var propValues = propValue.toArray();
     for (var i = 0, len = propValues.length; i < len; i++) {
-      var error = typeChecker(propValues, i, componentName, location, `${propFullName}[${i}]`);
+      var error = typeChecker(propValues, i, componentName, location, `${propFullName}[${i}]`, ...rest);
       if (error instanceof Error) {
         return error;
       }
@@ -120,7 +120,7 @@ function createIterableTypeChecker(typeChecker, immutableClassName, immutableCla
 
 function createKeysTypeChecker(typeChecker) {
 
-  function validate(props, propName, componentName, location, propFullName) {
+  function validate(props, propName, componentName, location, propFullName, ...rest) {
     var propValue = props[propName];
     if (typeof typeChecker !== 'function') {
       return new Error(
@@ -131,7 +131,7 @@ function createKeysTypeChecker(typeChecker) {
 
     var keys = propValue.keySeq().toArray();
     for (var i = 0, len = keys.length; i < len; i++) {
-      var error = typeChecker(keys, i, componentName, location, `${propFullName} -> key(${keys[i]})`);
+      var error = typeChecker(keys, i, componentName, location, `${propFullName} -> key(${keys[i]})`, ...rest);
       if (error instanceof Error) {
         return error;
       }
@@ -178,7 +178,7 @@ function createIterableOfTypeChecker(typeChecker) {
 }
 
 function createRecordOfTypeChecker(recordKeys) {
-  function validate(props, propName, componentName, location, propFullName) {
+  function validate(props, propName, componentName, location, propFullName, ...rest) {
     var propValue = props[propName];
     if (!(propValue instanceof Immutable.Record)) {
       var propType = getPropType(propValue);
@@ -194,7 +194,7 @@ function createRecordOfTypeChecker(recordKeys) {
         continue;
       }
       var mutablePropValue = propValue.toObject();
-      var error = checker(mutablePropValue, key, componentName, location, `${propFullName}.${key}`);
+      var error = checker(mutablePropValue, key, componentName, location, `${propFullName}.${key}`, ...rest);
       if (error) {
         return error;
       }
@@ -205,7 +205,7 @@ function createRecordOfTypeChecker(recordKeys) {
 
 // there is some irony in the fact that shapeTypes is a standard hash and not an immutable collection
 function createShapeTypeChecker(shapeTypes, immutableClassName = 'Iterable', immutableClassTypeValidator = Immutable.Iterable.isIterable) {
-  function validate(props, propName, componentName, location, propFullName) {
+  function validate(props, propName, componentName, location, propFullName, ...rest) {
     var propValue = props[propName];
     if (!immutableClassTypeValidator(propValue)) {
       var propType = getPropType(propValue);
@@ -221,7 +221,7 @@ function createShapeTypeChecker(shapeTypes, immutableClassName = 'Iterable', imm
       if (!checker) {
         continue;
       }
-      var error = checker(mutablePropValue, key, componentName, location, `${propFullName}.${key}`);
+      var error = checker(mutablePropValue, key, componentName, location, `${propFullName}.${key}`, ...rest);
       if (error) {
         return error;
       }


### PR DESCRIPTION
Fixes #35.

- [x] Use advice in https://facebook.github.io/react/warnings/dont-call-proptypes.html#fixing-the-false-positive-in-third-party-proptypes to update proptypes

I tested this in one of my own projects and it stopped the warnings. At the moment updating the React version to 15.3.0 and running the tests in this repo still generates the warnings. This is because the proptypes are being called outside of React (called like normal functions) so they don't get the new secret value just added in 15.3.0. You might need to update your tests at some point to actually render React components. I believe the React team test proptypes by rendering components and spying on `console.log` to verify them.