### PR TITLE
Add validators for Iterable.Indexed and Iterable.Keyed

### DIFF
--- a/src/ImmutablePropTypes.js
+++ b/src/ImmutablePropTypes.js
@@ -32,6 +32,9 @@ var ImmutablePropTypes = {
   iterable:   createImmutableTypeChecker('Iterable', Immutable.Iterable.isIterable)
 };
 
+ImmutablePropTypes.iterable.indexed = createIterableSubclassTypeChecker('Indexed', Immutable.Iterable.isIndexed);
+ImmutablePropTypes.iterable.keyed = createIterableSubclassTypeChecker('Keyed', Immutable.Iterable.isKeyed);
+
 function getPropType(propValue) {
   var propType = typeof propValue;
   if (Array.isArray(propValue)) {
@@ -85,6 +88,12 @@ function createImmutableTypeChecker(immutableClassName, immutableClassTypeValida
     return null;
   }
   return createChainableTypeChecker(validate);
+}
+
+function createIterableSubclassTypeChecker(subclassName, validator) {
+  return createImmutableTypeChecker(`Iterable.${subclassName}`, (propValue) =>
+    Immutable.Iterable.isIterable(propValue) && validator(propValue)
+  );
 }
 
 function createIterableTypeChecker(typeChecker, immutableClassName, immutableClassTypeValidator) {

--- a/src/__tests__/ImmutablePropTypes-test.js
+++ b/src/__tests__/ImmutablePropTypes-test.js
@@ -71,6 +71,18 @@ describe('ImmutablePropTypes', function() {
       typeCheckPass(PropTypes.iterable, Immutable.OrderedSet());
       typeCheckPass(PropTypes.iterable, Immutable.Stack());
       typeCheckPass(PropTypes.iterable, Immutable.Seq());
+      typeCheckPass(PropTypes.iterable, Immutable.Seq());
+      typeCheckPass(PropTypes.iterable.indexed, Immutable.Iterable.Indexed());
+      typeCheckPass(PropTypes.iterable.indexed, Immutable.List());
+      typeCheckPass(PropTypes.iterable.indexed, Immutable.Stack());
+      typeCheckPass(PropTypes.iterable.indexed, Immutable.Range());
+      typeCheckPass(PropTypes.iterable.indexed, Immutable.Repeat());
+      typeCheckPass(PropTypes.iterable.indexed, Immutable.Seq.Indexed());
+      typeCheckPass(PropTypes.iterable.keyed, Immutable.Iterable.Keyed());
+      typeCheckPass(PropTypes.iterable.keyed, Immutable.Map());
+      typeCheckPass(PropTypes.iterable.keyed, Immutable.OrderedMap());
+      typeCheckPass(PropTypes.iterable.keyed, new (Immutable.Record({a: 1}))());
+      typeCheckPass(PropTypes.iterable.keyed, Immutable.Seq.Keyed());
     });
     it('should warn for invalid lists', function() {
       typeCheckFail(
@@ -202,6 +214,168 @@ describe('ImmutablePropTypes', function() {
         Immutable.Iterable(),
         'Invalid prop `testProp` of type `Immutable.Seq` supplied to ' +
         '`testComponent`, expected `Record`.'
+      );
+    });
+    it('should warn for invalid iterables', function() {
+      typeCheckFail(
+        PropTypes.iterable,
+        [],
+        'Invalid prop `testProp` of type `array` supplied to ' +
+        '`testComponent`, expected `Iterable`.'
+      );
+      typeCheckFail(
+        PropTypes.iterable,
+        {},
+        'Invalid prop `testProp` of type `object` supplied to ' +
+        '`testComponent`, expected `Iterable`.'
+      );
+      typeCheckFail(
+        PropTypes.iterable,
+        '',
+        'Invalid prop `testProp` of type `string` supplied to ' +
+        '`testComponent`, expected `Iterable`.'
+      );
+      typeCheckFail(
+        PropTypes.iterable,
+        false,
+        'Invalid prop `testProp` of type `boolean` supplied to ' +
+        '`testComponent`, expected `Iterable`.'
+      );
+      typeCheckFail(
+        PropTypes.iterable,
+        0,
+        'Invalid prop `testProp` of type `number` supplied to ' +
+        '`testComponent`, expected `Iterable`.'
+      );
+    });
+    it('should warn for invalid indexed iterables', function() {
+      typeCheckFail(
+        PropTypes.iterable.indexed,
+        [],
+        'Invalid prop `testProp` of type `array` supplied to ' +
+        '`testComponent`, expected `Iterable.Indexed`.'
+      );
+      typeCheckFail(
+        PropTypes.iterable.indexed,
+        {},
+        'Invalid prop `testProp` of type `object` supplied to ' +
+        '`testComponent`, expected `Iterable.Indexed`.'
+      );
+      typeCheckFail(
+        PropTypes.iterable.indexed,
+        '',
+        'Invalid prop `testProp` of type `string` supplied to ' +
+        '`testComponent`, expected `Iterable.Indexed`.'
+      );
+      typeCheckFail(
+        PropTypes.iterable.indexed,
+        false,
+        'Invalid prop `testProp` of type `boolean` supplied to ' +
+        '`testComponent`, expected `Iterable.Indexed`.'
+      );
+      typeCheckFail(
+        PropTypes.iterable.indexed,
+        0,
+        'Invalid prop `testProp` of type `number` supplied to ' +
+        '`testComponent`, expected `Iterable.Indexed`.'
+      );
+      typeCheckFail(
+        PropTypes.iterable.indexed,
+        0,
+        'Invalid prop `testProp` of type `number` supplied to ' +
+        '`testComponent`, expected `Iterable.Indexed`.'
+      );
+      typeCheckFail(
+        PropTypes.iterable.indexed,
+        Immutable.Map(),
+        'Invalid prop `testProp` of type `Immutable.Map` supplied to ' +
+        '`testComponent`, expected `Iterable.Indexed`.'
+      );
+      typeCheckFail(
+        PropTypes.iterable.indexed,
+        Immutable.Set(),
+        'Invalid prop `testProp` of type `Immutable.Set` supplied to ' +
+        '`testComponent`, expected `Iterable.Indexed`.'
+      );
+      typeCheckFail(
+        PropTypes.iterable.indexed,
+         new (Immutable.Record({a: 1}))(),
+        'Invalid prop `testProp` of type `Immutable.Record` supplied to ' +
+        '`testComponent`, expected `Iterable.Indexed`.'
+      );
+    });
+    it('should warn for invalid keyed iterables', function() {
+      typeCheckFail(
+        PropTypes.iterable.keyed,
+        [],
+        'Invalid prop `testProp` of type `array` supplied to ' +
+        '`testComponent`, expected `Iterable.Keyed`.'
+      );
+      typeCheckFail(
+        PropTypes.iterable.keyed,
+        {},
+        'Invalid prop `testProp` of type `object` supplied to ' +
+        '`testComponent`, expected `Iterable.Keyed`.'
+      );
+      typeCheckFail(
+        PropTypes.iterable.keyed,
+        '',
+        'Invalid prop `testProp` of type `string` supplied to ' +
+        '`testComponent`, expected `Iterable.Keyed`.'
+      );
+      typeCheckFail(
+        PropTypes.iterable.keyed,
+        false,
+        'Invalid prop `testProp` of type `boolean` supplied to ' +
+        '`testComponent`, expected `Iterable.Keyed`.'
+      );
+      typeCheckFail(
+        PropTypes.iterable.keyed,
+        0,
+        'Invalid prop `testProp` of type `number` supplied to ' +
+        '`testComponent`, expected `Iterable.Keyed`.'
+      );
+      typeCheckFail(
+        PropTypes.iterable.keyed,
+        0,
+        'Invalid prop `testProp` of type `number` supplied to ' +
+        '`testComponent`, expected `Iterable.Keyed`.'
+      );
+      typeCheckFail(
+        PropTypes.iterable.keyed,
+        Immutable.List(),
+        'Invalid prop `testProp` of type `Immutable.List` supplied to ' +
+        '`testComponent`, expected `Iterable.Keyed`.'
+      );
+      typeCheckFail(
+        PropTypes.iterable.keyed,
+        Immutable.Set(),
+        'Invalid prop `testProp` of type `Immutable.Set` supplied to ' +
+        '`testComponent`, expected `Iterable.Keyed`.'
+      );
+      typeCheckFail(
+        PropTypes.iterable.keyed,
+        Immutable.OrderedSet(),
+        'Invalid prop `testProp` of type `Immutable.OrderedSet` supplied to ' +
+        '`testComponent`, expected `Iterable.Keyed`.'
+      );
+      typeCheckFail(
+        PropTypes.iterable.keyed,
+        Immutable.Stack(),
+        'Invalid prop `testProp` of type `Immutable.Stack` supplied to ' +
+        '`testComponent`, expected `Iterable.Keyed`.'
+      );
+      typeCheckFail(
+        PropTypes.iterable.keyed,
+        Immutable.Range(),
+        'Invalid prop `testProp` of type `Immutable.Range` supplied to ' +
+        '`testComponent`, expected `Iterable.Keyed`.'
+      );
+      typeCheckFail(
+        PropTypes.iterable.keyed,
+        Immutable.Repeat(),
+        'Invalid prop `testProp` of type `Immutable.Repeat` supplied to ' +
+        '`testComponent`, expected `Iterable.Keyed`.'
       );
     });
     it('should be implicitly optional and not warn without values', function() {


### PR DESCRIPTION
Validating that a `prop` inherits from `Iterable.Indexed` or `Iterable.Keyed` would be a helpful distinction.