### PR TITLE
fixes #53 - changing propValue.toArray() to propValue.valueSeq().toAr…

### DIFF
--- a/src/ImmutablePropTypes.js
+++ b/src/ImmutablePropTypes.js
@@ -153,7 +153,7 @@ function createIterableTypeChecker(typeChecker, immutableClassName, immutableCla
       );
     }
 
-    var propValues = propValue.toArray();
+    var propValues = propValue.valueSeq().toArray();
     for (var i = 0, len = propValues.length; i < len; i++) {
       var error = typeChecker(propValues, i, componentName, location, `${propFullName}[${i}]`, ...rest);
       if (error instanceof Error) {


### PR DESCRIPTION
This PR makes use of `.valueSeq().toArray()` for resolving the values of an iterable as it now returns entries in the case of Maps in immutable v4.