### PR TITLE
Add setOf to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,8 @@ const aMap = Immutable.Map([
 
 * `ImmutablePropTypes.orderedSetOf` is basically the same as `listOf`, but it is specific to `Immutable.OrderedSet`.
 
+* `ImmutablePropTypes.setOf` is basically the same as `listOf`, but it is specific to `Immutable.Set`.
+
 * `ImmutablePropTypes.stackOf` is basically the same as `listOf`, but it is specific to `Immutable.Stack`.
 
 * `ImmutablePropTypes.iterableOf` is the generic form of listOf/mapOf. It is useful when there is no need to validate anything other than Immutable.js compatible (ie. `Immutable.Iterable`). Continue to use `listOf` and/or `mapOf` when you know the type.


### PR DESCRIPTION
A tiny readme change that adds `setOf` to the list of API functions. My team wasn't sure whether `setOf` existed but found it after looking at the source so I decided to give the docs a quick update.